### PR TITLE
Move Renovate config out of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,5 @@
                 "width": 2000
             }
         }
-    },
-    "renovate": {
-        "extends": [
-            "@tryghost:theme",
-            "github>TryGhost/Themes//packages/theme-translations/renovate-config"
-        ]
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>TryGhost/renovate-config:theme.json5"
+    ]
+}


### PR DESCRIPTION
## Summary
- moved Zap's Renovate configuration from package.json into renovate.json
- extended the shared TryGhost theme Renovate preset used by the themes monorepo
- added the Renovate JSON schema reference for editor validation

## Validation
- jq empty package.json renovate.json