### PR TITLE
Split Zap theme test and deploy workflows

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -1,12 +1,10 @@
 # Learn more → https://github.com/TryGhost/action-deploy-theme#getting-started
-name: Zap
+name: Deploy Theme
 
 on:
-  pull_request:
   push:
     branches:
       - main
-      - 'renovate/*'
 
 permissions:
   contents: read
@@ -15,7 +13,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -38,7 +35,6 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test


### PR DESCRIPTION
## Summary
- added a PR-only `Test` workflow for Zap
- limited `Deploy Theme` to pushes on `main`
- kept deploy gated behind the same `pnpm test` job via `needs: test`

## Validation
- `pnpm test`
- parsed both workflow YAML files locally

`pnpm test` passes with the existing gscan warnings for `card_assets`, custom fonts, and `{{@page.show_title_and_feature_image}}`.