### PR TITLE
Fixed broken pnpm/action-setup pin in workflows

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:


### PR DESCRIPTION
## Summary

- The `pnpm/action-setup` digest `ac6db6d3c1f721f886538a378a2d73e85697340a` pinned in `test.yml` and `deploy-theme.yml` no longer exists upstream (GitHub returns HTTP 422 for it), so workflow jobs fail to resolve the action.
- Replaced it in both workflows with `0e279bb959325dab635dd2c09392533439d90093`, the verified digest behind the current `v6`/`v6.0.8` tag. No version comment was appended, matching the existing pin style in these files.
- Also checked whether `pnpm-workspace.yaml` leaks into the installable theme zip: the `zip` script uses explicit globs (`assets/* *.hbs package.json`) that cannot match it, so no zip change was needed.

Discovered during the monorepo pnpm migration review in TryGhost/Themes#529.

## Verification

- `gh api repos/pnpm/action-setup/commits/ac6db6d...` → HTTP 422 (digest gone); `.../commits/0e279bb...` resolves successfully.
- `pnpm install --frozen-lockfile` → clean install, lockfile up to date.
- `pnpm zip` + `unzip -l dist/zap.zip` → contains only `assets/screen.css`, the `.hbs` templates, and `package.json`; no pnpm files.
- `pnpm test` (gscan) → passes with 3 pre-existing, unrelated warnings.