### PR TITLE
Renamed CI gate job to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Branch protection on this repo currently requires the status check named `All tests pass`. Requiring a repo-specific (or legacy) check name couples branch protection to the CI matrix: rename the job and the required check silently stops existing, blocking every PR.

The org is standardizing every repository on a single stable aggregator check named `Required checks pass` (per the shared CI required-check convention), so rulesets can be applied uniformly across repos.

This PR renames the existing aggregator job (`all-tests-pass` / "All tests pass") to the standard shape (`required-checks-pass` / "Required checks pass"). Its behavior is unchanged: `if: always()`, `needs: [test]`, and a single step that fails on any failed or cancelled required job.

The branch ruleset is being updated in the same pass to require the new check, so this PR must go green on the new `Required checks pass` gate before merging.